### PR TITLE
Listen on both IPv4 and IPv6.

### DIFF
--- a/root/etc/haproxy/haproxy.cfg
+++ b/root/etc/haproxy/haproxy.cfg
@@ -20,7 +20,7 @@ defaults
         timeout server  15min
 
 frontend public
-        bind *:80
+        bind :::80 v4v6
         use_backend webcam if { path_beg /webcam/ }
         default_backend octoprint
 


### PR DESCRIPTION
Recent changes to Docker have made it so exposed ports that are bound to IPv6 will only forward to the IPv6 container address. This now requires the code in the container to listen on IPv6.

The "v4v6" part ensures that HAProxy will also listen on IPv4, regardless of system/container config.